### PR TITLE
Improve proper duration parsing

### DIFF
--- a/lib/parser/grammar.ex
+++ b/lib/parser/grammar.ex
@@ -147,14 +147,35 @@ defmodule Tempo.Iso8601.Parser.Grammar do
     ])
   end
 
-  def duration_element do
+  def duration_elements do
+    choice([
+      concat(duration_date_elements(), duration_time_elements()),
+      duration_date_elements(),
+      duration_time_elements()
+    ])
+  end
+
+  def duration_date_elements do
+    times(duration_date_element(), min: 1)
+  end
+
+  def duration_time_elements do
+    ignore(string("T")) |> times(duration_time_element(), min: 1)
+  end
+
+  def duration_date_element do
     choice([
       maybe_negative_integer() |> ignore(string("C")) |> unwrap_and_tag(:century),
       maybe_negative_integer() |> ignore(string("J")) |> unwrap_and_tag(:century),
       maybe_negative_integer() |> ignore(string("Y")) |> unwrap_and_tag(:year),
       maybe_negative_integer() |> ignore(string("M")) |> unwrap_and_tag(:month),
       maybe_negative_integer() |> ignore(string("W")) |> unwrap_and_tag(:week),
-      maybe_negative_integer() |> ignore(string("D")) |> unwrap_and_tag(:day),
+      maybe_negative_integer() |> ignore(string("D")) |> unwrap_and_tag(:day)
+    ])
+  end
+
+  def duration_time_element do
+    choice([
       maybe_negative_integer() |> ignore(string("H")) |> unwrap_and_tag(:hour),
       maybe_negative_integer() |> ignore(string("M")) |> unwrap_and_tag(:minute),
       maybe_negative_integer() |> ignore(string("S")) |> unwrap_and_tag(:second)

--- a/lib/parser/iso8601.ex
+++ b/lib/parser/iso8601.ex
@@ -54,6 +54,6 @@ defmodule Tempo.Iso8601.Parser do
   defcombinator :duration,
     optional(negative() |> replace({:direction, :negative}))
     |> ignore(string("P"))
-    |> times(duration_element(), min: 1)
+    |> concat(duration_elements())
     |> tag(:duration)
 end

--- a/test/tempo/iso8601/parser_test.exs
+++ b/test/tempo/iso8601/parser_test.exs
@@ -1,0 +1,33 @@
+defmodule Tempo.Iso8601.ParserTest do
+  use ExUnit.Case, async: true
+  alias Tempo.Iso8601.Parser
+
+  describe "iso8601/1" do
+    test "parsing simple iso dates" do
+      assert {:ok,
+              [
+                dattime: [
+                  year: 2020,
+                  month: 11,
+                  day_of_month: 14,
+                  hour: 10,
+                  minute: 11,
+                  second: 12
+                ]
+              ], "", _, _, _} = Parser.iso8601("2020-11-14T10:11:12")
+
+      assert {:ok, [date: [year: 2020, week: 28]], "", _, _, _} = Parser.iso8601("2020W28")
+
+      assert {:ok, [date: [year: 2020, day_of_year: 193]], "", _, _, _} =
+               Parser.iso8601("2020193")
+
+      assert {:ok, [date: [year: 2020, month: 11]], "", _, _, _} = Parser.iso8601("2020-11")
+    end
+
+    test "parsing simple iso durations" do
+      assert {:ok, [duration: [day: 1]], "", _, _, _} = Parser.iso8601("P1D")
+      assert {:ok, [duration: [hour: 24]], "", _, _, _} = Parser.iso8601("PT24H")
+      assert {:ok, [duration: [day: 1, hour: 3]], "", _, _, _} = Parser.iso8601("P1DT3H")
+    end
+  end
+end


### PR DESCRIPTION
Time component is separated from date components by a `T`

I hope this is correct given I've taken this from wikipedia (is there a spec for iso8601, which doesn't need to be bought?).