### PR TITLE
Sigils in matches

### DIFF
--- a/lib/sigil.ex
+++ b/lib/sigil.ex
@@ -44,7 +44,20 @@ defmodule Tempo.Sigils do
   call site.
 
   """
-  defmacro sigil_o({:<<>>, _meta, [string]}, opts) do
+  defmacro sigil_o({:<<>>, _meta, [_string]} = sigil, opts) do
+    do_sigil(__CALLER__.context, sigil, opts)
+  end
+
+  @doc """
+  Verbose alias for `sigil_o`. Use when `~o` might be confused with
+  another sigil in scope, or when you want the three-letter form
+  for readability in dense code.
+  """
+  defmacro sigil_TEMPO({:<<>>, _meta, [_string]} = sigil, opts) do
+    do_sigil(__CALLER__.context, sigil, opts)
+  end
+
+  defp do_sigil(nil, {:<<>>, _meta, [string]}, opts) do
     calendar = Options.calendar_from(opts)
 
     case Tempo.from_iso8601(string, calendar) do
@@ -53,18 +66,11 @@ defmodule Tempo.Sigils do
     end
   end
 
-  @doc """
-  Verbose alias for `sigil_o`. Use when `~o` might be confused with
-  another sigil in scope, or when you want the three-letter form
-  for readability in dense code.
-  """
-  defmacro sigil_TEMPO({:<<>>, _meta, [string]}, opts) do
-    calendar = Options.calendar_from(opts)
+  defp do_sigil(:match, {:<<>>, _meta, [string]}, opts) do
+  end
 
-    case Tempo.from_iso8601(string, calendar) do
-      {:ok, tempo} -> Macro.escape(tempo)
-      {:error, exception} -> raise exception
-    end
+  defp do_sigil(:guard, {:<<>>, _meta, [_string]}, _opts) do
+    raise ArgumentError, "invalid expression in guard"
   end
 end
 

--- a/lib/sigil.ex
+++ b/lib/sigil.ex
@@ -67,10 +67,60 @@ defmodule Tempo.Sigils do
   end
 
   defp do_sigil(:match, {:<<>>, _meta, [string]}, opts) do
+    calendar = Options.calendar_from(opts)
+
+    case Tempo.from_iso8601(string, calendar) do
+      {:ok, %Tempo{time: time}} ->
+        time_pattern = build_time_match_pattern(time)
+
+        quote do
+          %Tempo{time: unquote(time_pattern)}
+        end
+
+      {:ok, other} ->
+        raise ArgumentError,
+              "~o sigil in a match context only supports simple %Tempo{} values; " <>
+                "got #{inspect(other.__struct__)}"
+
+      {:error, exception} ->
+        raise exception
+    end
   end
 
   defp do_sigil(:guard, {:<<>>, _meta, [_string]}, _opts) do
     raise ArgumentError, "invalid expression in guard"
+  end
+
+  # Build a cons-pattern AST ending in `| _` from a time keyword
+  # list. The resulting quoted expression, when spliced into a
+  # `%Tempo{time: ...}` pattern, matches any Tempo whose canonical
+  # `time` list starts with the given `{unit, value}` pairs.
+  #
+  # Only simple integer-valued components are supported. Complex
+  # AST shapes (groups, selections, ranges, margin-of-error
+  # tuples, continuations) raise at macro-expansion time.
+  defp build_time_match_pattern([]) do
+    quote do: _
+  end
+
+  defp build_time_match_pattern([{unit, value} | rest]) do
+    assert_matchable!(unit, value)
+    tail = build_time_match_pattern(rest)
+
+    quote do
+      [{unquote(unit), unquote(value)} | unquote(tail)]
+    end
+  end
+
+  # Integers (including negatives) are valid literal patterns.
+  # Anything else indicates a non-simple Tempo component that we
+  # don't yet know how to express as a static Elixir pattern.
+  defp assert_matchable!(_unit, value) when is_integer(value), do: :ok
+
+  defp assert_matchable!(unit, value) do
+    raise ArgumentError,
+          "~o sigil in a match context only supports simple integer components; " <>
+            "got #{inspect(unit)}: #{inspect(value)}"
   end
 end
 

--- a/lib/sigil.ex
+++ b/lib/sigil.ex
@@ -1,10 +1,12 @@
 defmodule Tempo.Sigils do
   @moduledoc """
-  Sigils for constructing `%Tempo{}` values at compile time.
+  Sigils for constructing and pattern-matching `%Tempo{}` values at
+  compile time.
 
   Provides `~o` (and its verbose alias `~TEMPO`) to turn an ISO 8601
-  / ISO 8601-2 / IXDTF / EDTF string into a `%Tempo{}`, `%Tempo.Interval{}`,
-  `%Tempo.Duration{}`, or `%Tempo.Set{}` struct.
+  / ISO 8601-2 / IXDTF / EDTF string into a `%Tempo{}`,
+  `%Tempo.Interval{}`, `%Tempo.Duration{}`, `%Tempo.Range{}`, or
+  `%Tempo.Set{}` struct — or into a pattern that matches one.
 
   ```elixir
   import Tempo.Sigils
@@ -23,13 +25,219 @@ defmodule Tempo.Sigils do
   namespace. Any expansion-time helpers live in a private sibling
   module that isn't part of the public API.
 
-  ### Modifiers
+  ### Modifiers in value context
+
+  When `~o"…"` appears as an expression that produces a value (the
+  default context), a single modifier letter selects the calendar
+  the string is parsed against:
 
   * No modifier — Gregorian calendar (the common case).
 
   * `w` — ISO Week calendar (`Calendrical.ISOWeek`). Use when the
     input is in a week-based form you want parsed under ISO week
     semantics explicitly.
+
+  ## Match context
+
+  When `~o"…"` is used on the left-hand side of a match —
+  `match?/2`, `case` clauses, `=`, or function-head patterns —
+  the sigil expands to a **structural pattern** rather than a
+  literal value. The generated pattern is deliberately permissive:
+  it constrains only what the sigil string actually names.
+
+  ### 1. Prefix matching on `%Tempo{}` and `%Tempo.Duration{}`
+
+  The sigil string is parsed as usual; the resulting `:time`
+  keyword list becomes a cons-pattern terminated by a wildcard,
+  so the sigil matches any value whose `:time` *starts with* the
+  listed `{unit, value}` pairs. Other struct fields
+  (`:calendar`, `:shift`, `:extended`, `:qualification`, …) are
+  left unconstrained — a Gregorian-looking sigil matches a
+  Hebrew-calendar value just as happily, because the intent of
+  the sigil is purely temporal.
+
+  ```elixir
+  import Tempo.Sigils
+
+  today = Tempo.new!(year: 2026, month: 4, day: 24)
+
+  match?(~o[2026Y], today)          #=> true  — year prefix
+  match?(~o[2026Y4M], today)        #=> true  — year+month prefix
+  match?(~o[2026Y4M24D], today)     #=> true  — full prefix
+  match?(~o[2026Y1M], today)        #=> false — month disagrees
+  match?(~o[2025Y], today)          #=> false — year disagrees
+
+  hebrew = Tempo.new!(year: 2026, month: 4, day: 24,
+                      calendar: Calendrical.Hebrew)
+  match?(~o[2026Y], hebrew)         #=> true  — :calendar is free
+
+  duration = Tempo.Duration.new!(year: 1, month: 6)
+  match?(~o[P1Y6M], duration)       #=> true
+  match?(~o[P2Y6M], duration)       #=> false
+  match?(~o[1Y6M], duration)        #=> false  — %Tempo{} sigil
+                                    #            vs %Duration{}
+  ```
+
+  ### 2. Modifier-driven bindings
+
+  Modifier letters after the closing delimiter bind the matched
+  value's unit to a same-named variable in the caller's scope.
+  Bindings are only meaningful on `%Tempo{}` and
+  `%Tempo.Duration{}` values — the only shapes with a
+  `:time` keyword list to destructure.
+
+  Letter → unit mapping (deliberately avoids overloading `M`,
+  which ISO 8601 uses for both month and minute):
+
+  * `Y` — year
+  * `O` — month (`mOnth`)
+  * `W` — week
+  * `D` — day
+  * `I` — day of year
+  * `K` — day of week
+  * `H` — hour
+  * `N` — minute (`miNute`)
+  * `S` — second
+
+  The pattern builder lays out the canonical calendar-axis slice
+  between the earliest and latest unit requested (either by the
+  sigil literal or by a modifier), filling positions not named
+  with wildcards. Axis choice — Gregorian, ISO week, or ordinal
+  — is inferred from the union of sigil and modifier units.
+
+  ```elixir
+  import Tempo.Sigils
+
+  today = Tempo.new!(year: 2026, month: 4, day: 24)
+
+  case today do
+    ~o[2026Y]D -> day                 #=> 24
+  end
+
+  case today do
+    ~o[2026Y]OD -> {month, day}       #=> {4, 24}
+  end
+
+  point = Tempo.new!(year: 2026, month: 6, day: 15,
+                     hour: 14, minute: 30, second: 45)
+
+  case point do
+    ~o[2026Y6M]DN -> {day, minute}    #=> {15, 30}
+  end
+
+  case point do
+    ~o[2026Y6M15DT14H30M]S -> second  #=> 45
+  end
+
+  duration = Tempo.Duration.new!(year: 1, month: 6, day: 15)
+
+  case duration do
+    ~o[P1Y]D -> day                   #=> 15
+  end
+  ```
+
+  A modifier that targets a unit the matched value doesn't carry
+  simply fails to match; the `case` falls through to the next
+  clause. Modifier order inside the sigil is irrelevant —
+  `~o[2026Y]DN` and `~o[2026Y]ND` expand to the same pattern.
+
+  #### Expansion-time errors
+
+  * Unknown modifier letter → `ArgumentError`.
+  * Modifier targets a unit already fixed by the sigil (e.g.
+    `~o[2026Y]Y`) → `ArgumentError`.
+  * Mixing calendar axes (e.g. `~o[2026Y4M]W` — Gregorian
+    month plus ISO week) → `ArgumentError`.
+
+  ### 3. Matching containers
+
+  The sigil also expands to a structural pattern when the parsed
+  value is a container: `%Tempo.Interval{}`, `%Tempo.Range{}`,
+  or `%Tempo.Set{}`. Each endpoint is itself prefix-matched
+  using the phase-1 rules, so an endpoint sigil like `~o"2022Y"`
+  inside an interval matches any Tempo whose `:time` starts with
+  year 2022.
+
+  Container patterns only constrain fields the sigil string
+  actually names. For intervals, that means `from` and `to` are
+  always constrained, while `duration`, `recurrence`,
+  `direction`, and `repeat_rule` are only constrained when they
+  differ from their struct defaults — so
+  `~o[1984Y/2004Y]` doesn't accidentally require
+  `metadata: %{}`.
+
+  ```elixir
+  import Tempo.Sigils
+
+  {:ok, closed}   = Tempo.from_iso8601("1984Y/2004Y")
+  {:ok, open_up}  = Tempo.from_iso8601("1984/..")
+  {:ok, dur_iv}   = Tempo.from_iso8601("P1D/2022-01-01")
+
+  match?(~o[1984Y/2004Y], closed)    #=> true
+  match?(~o[1984Y/..], closed)       #=> false — closed vs open
+  match?(~o[1984Y/..], open_up)      #=> true
+  match?(~o[../..], open_up)         #=> false
+  match?(~o[P1D/2022-01-01], dur_iv) #=> true
+
+  {:ok, one_of}   = Tempo.from_iso8601("[1984,1986,1988]")
+  {:ok, all_of}   = Tempo.from_iso8601("{1960,1961-12}")
+
+  match?(~o"[1984Y,1986Y,1988Y]", one_of)  #=> true
+  match?(~o"{1960Y,1961Y12M}", all_of)     #=> true
+  match?(~o"{1984Y,1986Y,1988Y}", one_of)  #=> false — :one ≠ :all
+  ```
+
+  Sets whose literal text begins with `[` or `{` collide with
+  the `~o[…]` and `~o{…}` delimiters, so use the string-delim
+  form `~o"…"` for them.
+
+  Set members are matched in order and by count — a sigil set
+  with three members never matches a value with two or four.
+  Ranges (`%Tempo.Range{first: …, last: …}`) are matched
+  structurally whether they appear at the top level or nested
+  inside a `%Tempo.Set{}`.
+
+  #### Modifiers on containers
+
+  Modifier bindings are **not** accepted on `%Tempo.Interval{}`,
+  `%Tempo.Range{}`, `%Tempo.Set{}`, or `%Tempo.IntervalSet{}`
+  sigils — there is no single keyword-list `:time` to
+  destructure. Using one raises `ArgumentError` at expansion
+  time. Reach into an interval's endpoint manually:
+
+  ```elixir
+  case interval do
+    ~o[1984Y/..] ->
+      %Tempo.Interval{from: ~o[1984Y]D = from} = interval
+      from.time[:day]
+  end
+  ```
+
+  ### 4. Guards
+
+  Patterns from `~o"…"` cannot appear in a `when` clause. The
+  sigil detects the `:guard` context and raises
+  `ArgumentError` with a clear message — use a preceding match
+  + `==` comparison instead.
+
+  ### 5. What match context does **not** do
+
+  * **No calendar modifier.** `W` in value context selects the
+    ISO Week calendar; in match context it always means "bind
+    `:week`". Sigils in match context always parse their
+    string as Gregorian and leave the matched value's
+    `:calendar` field unconstrained.
+
+  * **No stdlib types.** `~o"…"` produces a `%Tempo{}`-family
+    pattern, so it cannot match `%Date{}`, `%Time{}`,
+    `%NaiveDateTime{}`, or `%DateTime{}`. For those, use
+    `~D`/`~T`/`~N`/`~U` directly, or convert the value with
+    `Tempo.from_elixir/1` before matching.
+
+  * **No complex time elements.** Groups, selections, ranges,
+    margin-of-error tuples, and continuations aren't expressible
+    as static Elixir patterns — attempting to use a sigil that
+    contains them in match context raises `ArgumentError`.
 
   """
 

--- a/lib/sigil.ex
+++ b/lib/sigil.ex
@@ -101,20 +101,8 @@ defmodule Tempo.Sigils do
     bindings = bindings_from_modifiers(opts)
 
     case Tempo.from_iso8601(string, Calendrical.Gregorian) do
-      {:ok, %Tempo{time: time}} ->
-        time_pattern = build_time_match_pattern(time, bindings)
-
-        quote do
-          %Tempo{time: unquote(time_pattern)}
-        end
-
-      {:ok, other} ->
-        raise ArgumentError,
-              "~o sigil in a match context only supports simple %Tempo{} values; " <>
-                "got #{inspect(other.__struct__)}"
-
-      {:error, exception} ->
-        raise exception
+      {:ok, parsed} -> build_match_pattern(parsed, bindings)
+      {:error, exception} -> raise exception
     end
   end
 
@@ -141,6 +129,65 @@ defmodule Tempo.Sigils do
                   "K (day-of-week), H (hour), N (minute), S (second)"
       end
     end)
+  end
+
+  # Dispatch on the struct that the parser produced. `%Tempo{}`
+  # and `%Tempo.Duration{}` share a keyword-list `time` field, so
+  # modifier bindings work for both; containers (intervals,
+  # ranges, sets) match structurally and refuse modifiers.
+  defp build_match_pattern(%Tempo{time: time}, bindings) do
+    time_pattern = build_time_match_pattern(time, bindings)
+
+    quote do
+      %Tempo{time: unquote(time_pattern)}
+    end
+  end
+
+  defp build_match_pattern(%Tempo.Duration{time: time}, bindings) do
+    time_pattern = build_time_match_pattern(time, bindings)
+
+    quote do
+      %Tempo.Duration{time: unquote(time_pattern)}
+    end
+  end
+
+  defp build_match_pattern(%Tempo.Interval{} = interval, bindings) do
+    reject_container_bindings!(bindings, Tempo.Interval)
+    interval_pattern(interval)
+  end
+
+  defp build_match_pattern(%Tempo.Range{} = range, bindings) do
+    reject_container_bindings!(bindings, Tempo.Range)
+    range_pattern(range)
+  end
+
+  defp build_match_pattern(%Tempo.Set{} = set, bindings) do
+    reject_container_bindings!(bindings, Tempo.Set)
+    set_pattern(set)
+  end
+
+  # `%Tempo.IntervalSet{}` is produced by `Tempo.to_interval/1`,
+  # not by `Tempo.from_iso8601/2` — so a sigil string can't
+  # materialise to one in practice. Kept here for exhaustiveness
+  # in case future grammar extensions produce one.
+  defp build_match_pattern(%Tempo.IntervalSet{} = interval_set, bindings) do
+    reject_container_bindings!(bindings, Tempo.IntervalSet)
+    interval_set_pattern(interval_set)
+  end
+
+  defp build_match_pattern(other, _bindings) do
+    raise ArgumentError,
+          "~o sigil in a match context does not support matching on " <>
+            "#{inspect(other.__struct__)} values"
+  end
+
+  defp reject_container_bindings!([], _module), do: :ok
+
+  defp reject_container_bindings!(bindings, module) do
+    raise ArgumentError,
+          "~o sigil modifier bindings #{inspect(bindings)} are only " <>
+            "supported on %Tempo{} and %Tempo.Duration{} values; " <>
+            "#{inspect(module)} values match structurally only"
   end
 
   # Build a cons-pattern AST ending in `| _` for the `time` field
@@ -276,6 +323,112 @@ defmodule Tempo.Sigils do
 
       idx ->
         idx
+    end
+  end
+
+  # ---- Container patterns -----------------------------------
+
+  # Pattern for a value that appears as an endpoint on an
+  # `Interval`, `Range`, or `Set`. `:undefined` is used by the
+  # parser for open endpoints; `nil` can appear on intervals
+  # constructed without a `from` or `to` (e.g. a bare RRULE).
+  # Concrete `%Tempo{}` / `%Tempo.Duration{}` endpoints reuse the
+  # prefix-match semantics of phase ①/② so that an endpoint like
+  # `~o"2022Y"` matches any Tempo whose `time` starts with year
+  # 2022.
+  defp endpoint_pattern(:undefined), do: :undefined
+  defp endpoint_pattern(nil), do: nil
+
+  defp endpoint_pattern(%Tempo{time: time}) do
+    time_pattern = build_time_match_pattern(time, [])
+
+    quote do
+      %Tempo{time: unquote(time_pattern)}
+    end
+  end
+
+  defp endpoint_pattern(%Tempo.Duration{time: time}) do
+    time_pattern = build_time_match_pattern(time, [])
+
+    quote do
+      %Tempo.Duration{time: unquote(time_pattern)}
+    end
+  end
+
+  # Intervals carry 7 fields but most are optional metadata. The
+  # pattern only constrains fields that differ from their struct
+  # defaults (so an interval built from `1984/2004` doesn't
+  # accidentally require `metadata: %{}`, `direction: 1`, etc.).
+  defp interval_pattern(%Tempo.Interval{
+         from: from,
+         to: to,
+         duration: duration,
+         recurrence: recurrence,
+         direction: direction,
+         repeat_rule: repeat_rule
+       }) do
+    fields =
+      [from: endpoint_pattern(from), to: endpoint_pattern(to)]
+      |> maybe_put_field(:duration, duration, &endpoint_pattern/1, &is_nil/1)
+      |> maybe_put_field(:recurrence, recurrence, & &1, &(&1 == 1))
+      |> maybe_put_field(:direction, direction, & &1, &(&1 == 1))
+      |> maybe_put_field(:repeat_rule, repeat_rule, &endpoint_pattern/1, &is_nil/1)
+
+    {:%, [],
+     [
+       {:__aliases__, [alias: false], [:Tempo, :Interval]},
+       {:%{}, [], fields}
+     ]}
+  end
+
+  defp range_pattern(%Tempo.Range{first: first, last: last}) do
+    first_ast = endpoint_pattern(first)
+    last_ast = endpoint_pattern(last)
+
+    quote do
+      %Tempo.Range{first: unquote(first_ast), last: unquote(last_ast)}
+    end
+  end
+
+  # Sets either enumerate explicit members (`%Tempo.Set{}` with
+  # `:all`/`:one`) or hold ranges. Member order and length are
+  # constrained by the pattern — a sigil set only matches a Set
+  # whose `:set` list has the same members in the same order.
+  defp set_pattern(%Tempo.Set{type: type, set: members}) do
+    member_asts = Enum.map(members, &set_member_pattern/1)
+
+    quote do
+      %Tempo.Set{type: unquote(type), set: unquote(member_asts)}
+    end
+  end
+
+  defp set_member_pattern(%Tempo.Range{} = range), do: range_pattern(range)
+  defp set_member_pattern(%Tempo{} = tempo), do: endpoint_pattern(tempo)
+  defp set_member_pattern(%Tempo.Duration{} = duration), do: endpoint_pattern(duration)
+
+  defp set_member_pattern(other) do
+    raise ArgumentError,
+          "~o sigil in a match context does not support set members of type " <>
+            "#{inspect(other.__struct__)}"
+  end
+
+  defp interval_set_pattern(%Tempo.IntervalSet{intervals: intervals}) do
+    interval_asts = Enum.map(intervals, &interval_pattern/1)
+
+    quote do
+      %Tempo.IntervalSet{intervals: unquote(interval_asts)}
+    end
+  end
+
+  # Append `{field, transform.(value)}` to `fields` when `value`
+  # differs from its default (as reported by `default?`). Keeps
+  # container patterns free of spurious constraints on fields the
+  # sigil string didn't actually mention.
+  defp maybe_put_field(fields, field, value, transform, default?) do
+    if default?.(value) do
+      fields
+    else
+      fields ++ [{field, transform.(value)}]
     end
   end
 end

--- a/lib/sigil.ex
+++ b/lib/sigil.ex
@@ -66,12 +66,43 @@ defmodule Tempo.Sigils do
     end
   end
 
-  defp do_sigil(:match, {:<<>>, _meta, [string]}, opts) do
-    calendar = Options.calendar_from(opts)
+  # Modifier letters accepted in match context and the unit they
+  # bind. `M` is deliberately absent — ISO 8601 overloads it for
+  # both month and minute, so match-context modifiers use `O` for
+  # month and `N` for minute to keep the binding unambiguous.
+  @modifier_to_unit %{
+    ?Y => :year,
+    ?O => :month,
+    ?W => :week,
+    ?D => :day,
+    ?I => :day_of_year,
+    ?K => :day_of_week,
+    ?H => :hour,
+    ?N => :minute,
+    ?S => :second
+  }
 
-    case Tempo.from_iso8601(string, calendar) do
+  # Canonical unit sequences per calendar axis. A `~o[…]`-bound
+  # pattern picks the axis that covers every unit named (sigil or
+  # modifier) and lays elements out in that axis's order, with
+  # wildcards filling positions not explicitly requested.
+  @gregorian_axis [:year, :month, :day, :hour, :minute, :second]
+  @iso_week_axis [:year, :week, :day_of_week, :hour, :minute, :second]
+  @ordinal_axis [:year, :day_of_year, :hour, :minute, :second]
+
+  defp do_sigil(:match, {:<<>>, _meta, [string]}, opts) do
+    # Match-context modifiers are always binding letters — a
+    # departure from value context, where `W` selects the ISO
+    # week calendar. The sigil string is therefore always parsed
+    # with `Calendrical.Gregorian`; the generated pattern does
+    # not constrain the target's `:calendar` field either, so a
+    # Gregorian-looking sigil still matches e.g. a Hebrew value
+    # at the same `time` prefix.
+    bindings = bindings_from_modifiers(opts)
+
+    case Tempo.from_iso8601(string, Calendrical.Gregorian) do
       {:ok, %Tempo{time: time}} ->
-        time_pattern = build_time_match_pattern(time)
+        time_pattern = build_time_match_pattern(time, bindings)
 
         quote do
           %Tempo{time: unquote(time_pattern)}
@@ -91,25 +122,106 @@ defmodule Tempo.Sigils do
     raise ArgumentError, "invalid expression in guard"
   end
 
-  # Build a cons-pattern AST ending in `| _` from a time keyword
-  # list. The resulting quoted expression, when spliced into a
-  # `%Tempo{time: ...}` pattern, matches any Tempo whose canonical
-  # `time` list starts with the given `{unit, value}` pairs.
+  # Resolve the modifier char list to a list of unit atoms to
+  # bind. Order in the sigil is irrelevant — the pattern builder
+  # re-sorts by axis position.
+  defp bindings_from_modifiers([]), do: []
+
+  defp bindings_from_modifiers(letters) when is_list(letters) do
+    Enum.map(letters, fn letter ->
+      case Map.fetch(@modifier_to_unit, letter) do
+        {:ok, unit} ->
+          unit
+
+        :error ->
+          raise ArgumentError,
+                "~o sigil in a match context does not recognise modifier " <>
+                  "#{inspect(<<letter::utf8>>)}; valid modifiers are " <>
+                  "Y (year), O (month), W (week), D (day), I (day-of-year), " <>
+                  "K (day-of-week), H (hour), N (minute), S (second)"
+      end
+    end)
+  end
+
+  # Build a cons-pattern AST ending in `| _` for the `time` field
+  # of the generated `%Tempo{}` pattern. The pattern lays out the
+  # canonical axis slice between the earliest and latest unit
+  # requested (whether via the sigil literal or a binding
+  # modifier), filling each position with either the literal
+  # value, the binding variable, or a wildcard.
   #
-  # Only simple integer-valued components are supported. Complex
-  # AST shapes (groups, selections, ranges, margin-of-error
-  # tuples, continuations) raise at macro-expansion time.
-  defp build_time_match_pattern([]) do
+  # Only simple integer-valued components from the parsed sigil
+  # are supported. Complex AST shapes (groups, selections,
+  # ranges, margin-of-error tuples, continuations) raise at
+  # macro-expansion time.
+  defp build_time_match_pattern([], []) do
     quote do: _
   end
 
-  defp build_time_match_pattern([{unit, value} | rest]) do
-    assert_matchable!(unit, value)
-    tail = build_time_match_pattern(rest)
+  defp build_time_match_pattern(time, bindings) do
+    sigil_units = Keyword.keys(time)
+    assert_no_modifier_duplicates!(sigil_units, bindings)
+
+    all_units = sigil_units ++ bindings
+    axis = axis_for(all_units)
+
+    indexes = Enum.map(all_units, &index_in_axis!(&1, axis))
+    first_index = Enum.min(indexes)
+    last_index = Enum.max(indexes)
+
+    axis
+    |> Enum.slice(first_index..last_index)
+    |> Enum.map(&element_for_unit(&1, time, bindings))
+    |> build_cons_pattern()
+  end
+
+  # Pick the appropriate element shape for a canonical-axis
+  # position: the sigil's literal value wins, a modifier binding
+  # comes next, and unrequested positions become `_` wildcards.
+  defp element_for_unit(unit, time, bindings) do
+    cond do
+      Keyword.has_key?(time, unit) ->
+        value = Keyword.fetch!(time, unit)
+        assert_matchable!(unit, value)
+        {:fixed, unit, value}
+
+      unit in bindings ->
+        {:bind, unit}
+
+      true ->
+        :wildcard
+    end
+  end
+
+  defp build_cons_pattern([]) do
+    quote do: _
+  end
+
+  defp build_cons_pattern([elem | rest]) do
+    head = element_to_ast(elem)
+    tail = build_cons_pattern(rest)
 
     quote do
-      [{unquote(unit), unquote(value)} | unquote(tail)]
+      [unquote(head) | unquote(tail)]
     end
+  end
+
+  defp element_to_ast({:fixed, unit, value}) do
+    quote do: {unquote(unit), unquote(value)}
+  end
+
+  # Bind the unit's value to a same-named variable in the
+  # caller's context — `D` binds `day`, `N` binds `minute`, etc.
+  # `Macro.var(unit, nil)` uses hygienic context `nil`, matching
+  # how the standard library's pattern-producing sigils (e.g.
+  # `~D`) expose bindings.
+  defp element_to_ast({:bind, unit}) do
+    var = Macro.var(unit, nil)
+    quote do: {unquote(unit), unquote(var)}
+  end
+
+  defp element_to_ast(:wildcard) do
+    quote do: _
   end
 
   # Integers (including negatives) are valid literal patterns.
@@ -121,6 +233,50 @@ defmodule Tempo.Sigils do
     raise ArgumentError,
           "~o sigil in a match context only supports simple integer components; " <>
             "got #{inspect(unit)}: #{inspect(value)}"
+  end
+
+  defp assert_no_modifier_duplicates!(sigil_units, bindings) do
+    dupes = for u <- bindings, u in sigil_units, do: u
+
+    if dupes != [] do
+      raise ArgumentError,
+            "~o sigil modifier binds a unit already present in the sigil literal: " <>
+              "#{inspect(dupes)}"
+    end
+  end
+
+  # Derive the calendar axis (Gregorian / ISO week / ordinal)
+  # that every requested unit has to belong to. Axis mixing is
+  # an expansion-time error — a user can't meaningfully match
+  # `:month` and `:week` on the same value.
+  defp axis_for(units) do
+    week? = Enum.any?(units, &(&1 in [:week, :day_of_week]))
+    ordinal? = Enum.any?(units, &(&1 == :day_of_year))
+    gregorian? = Enum.any?(units, &(&1 in [:month, :day]))
+
+    if Enum.count([week?, ordinal?, gregorian?], & &1) > 1 do
+      raise ArgumentError,
+            "~o sigil in a match context cannot mix calendar axes: " <>
+              "#{inspect(units)}"
+    end
+
+    cond do
+      week? -> @iso_week_axis
+      ordinal? -> @ordinal_axis
+      true -> @gregorian_axis
+    end
+  end
+
+  defp index_in_axis!(unit, axis) do
+    case Enum.find_index(axis, &(&1 == unit)) do
+      nil ->
+        raise ArgumentError,
+              "~o sigil in a match context cannot place unit #{inspect(unit)} " <>
+                "on the inferred calendar axis #{inspect(axis)}"
+
+      idx ->
+        idx
+    end
   end
 end
 

--- a/test/tempo/sigil_test.exs
+++ b/test/tempo/sigil_test.exs
@@ -1,0 +1,112 @@
+defmodule Tempo.SigilMatchTest do
+  use ExUnit.Case, async: true
+  import Tempo.Sigils
+
+  # Phase ① behaviour of `~o[…]` used on the LHS of a match —
+  # `match?/2`, `case`, function-head patterns. The sigil expands
+  # to a `%Tempo{time: [{u1, v1}, …, {un, vn} | _]}` pattern,
+  # leaving `calendar`, `shift`, `extended`, `qualification`, and
+  # `qualifications` unconstrained.
+
+  describe "match?/2 with ~o[...]" do
+    test "year-only sigil matches any Tempo starting with that year" do
+      today = Tempo.new!(year: 2026, month: 4, day: 24)
+      assert match?(~o[2026Y], today)
+    end
+
+    test "year-only sigil does not match a different year" do
+      today = Tempo.new!(year: 2026, month: 4, day: 24)
+      refute match?(~o[2025Y], today)
+    end
+
+    test "year+month sigil rejects a Tempo with a different month" do
+      today = Tempo.new!(year: 2026, month: 4, day: 24)
+      refute match?(~o[2026Y01M], today)
+    end
+
+    test "year+month sigil accepts a Tempo with the same month (extra units allowed)" do
+      today = Tempo.new!(year: 2026, month: 4, day: 24)
+      assert match?(~o[2026Y4M], today)
+    end
+
+    test "full date sigil matches an exact value" do
+      today = Tempo.new!(year: 2026, month: 4, day: 24)
+      assert match?(~o[2026Y4M24D], today)
+    end
+
+    test "full date sigil rejects a later finer value" do
+      today = Tempo.new!(year: 2026, month: 4, day: 25)
+      refute match?(~o[2026Y4M24D], today)
+    end
+
+    test "datetime sigil matches a Tempo with the same head" do
+      point = Tempo.new!(year: 2026, month: 6, day: 15, hour: 14, minute: 30, second: 45)
+      assert match?(~o[2026Y6M15DT14H], point)
+      assert match?(~o[2026Y6M15DT14H30M], point)
+      assert match?(~o[2026Y6M15DT14H30M45S], point)
+    end
+
+    test "sigil with a unit the target Tempo lacks does not match" do
+      bare_year = Tempo.new!(year: 2026)
+      refute match?(~o[2026Y4M], bare_year)
+    end
+
+    test "calendar of target is irrelevant — only `time` is constrained" do
+      hebrew = Tempo.new!(year: 2026, month: 4, day: 24, calendar: Calendrical.Hebrew)
+      assert match?(~o[2026Y], hebrew)
+      assert match?(~o[2026Y4M], hebrew)
+    end
+
+    test "shift / zone metadata on the target does not prevent a match" do
+      zoned = Tempo.new!(year: 2026, month: 4, day: 24, hour: 10, shift: [hour: 5])
+      assert match?(~o[2026Y4M24D], zoned)
+    end
+  end
+
+  describe "~o[...] inside a case expression" do
+    test "dispatches to the first matching branch" do
+      today = Tempo.new!(year: 2026, month: 4, day: 24)
+
+      result =
+        case today do
+          ~o[2025Y] -> :last_year
+          ~o[2026Y01M] -> :january
+          ~o[2026Y] -> :this_year
+          _ -> :other
+        end
+
+      assert result == :this_year
+    end
+
+    test "falls through to the default branch when nothing matches" do
+      today = Tempo.new!(year: 2026, month: 4, day: 24)
+
+      result =
+        case today do
+          ~o[2025Y] -> :nope
+          ~o[2027Y] -> :still_nope
+          _ -> :default
+        end
+
+      assert result == :default
+    end
+  end
+
+  describe "expansion-time errors" do
+    test "raises ArgumentError when used in a guard" do
+      # Guards are a stricter context than matches — the existing
+      # guard clause rejects them outright, and phase ① leaves
+      # that behaviour unchanged.
+      assert_raise ArgumentError, ~r/invalid expression in guard/, fn ->
+        Code.eval_string(
+          """
+          import Tempo.Sigils
+
+          fn t when t == ~o[2026Y] -> :ok end
+          """,
+          []
+        )
+      end
+    end
+  end
+end

--- a/test/tempo/sigil_test.exs
+++ b/test/tempo/sigil_test.exs
@@ -109,4 +109,175 @@ defmodule Tempo.SigilMatchTest do
       end
     end
   end
+
+  # Phase ② — modifier letters bind the matched value's unit to a
+  # same-named variable. Wildcards fill canonical positions
+  # between the sigil's last explicit unit and the modifier's
+  # target.
+
+  describe "modifier bindings — single binding" do
+    test "D binds day even when month sits between year and day" do
+      today = Tempo.new!(year: 2026, month: 4, day: 24)
+
+      assert (case today do
+                ~o[2026Y]D -> day
+              end) == 24
+    end
+
+    test "D binds day when month is also fixed in the sigil" do
+      today = Tempo.new!(year: 2026, month: 4, day: 24)
+
+      assert (case today do
+                ~o[2026Y4M]D -> day
+              end) == 24
+    end
+
+    test "O binds month" do
+      today = Tempo.new!(year: 2026, month: 4, day: 24)
+
+      assert (case today do
+                ~o[2026Y]O -> month
+              end) == 4
+    end
+
+    test "H binds hour on a full datetime" do
+      point = Tempo.new!(year: 2026, month: 6, day: 15, hour: 14, minute: 30)
+
+      assert (case point do
+                ~o[2026Y6M15D]H -> hour
+              end) == 14
+    end
+
+    test "N binds minute on a full datetime" do
+      point = Tempo.new!(year: 2026, month: 6, day: 15, hour: 14, minute: 30)
+
+      assert (case point do
+                ~o[2026Y6M15DT14H]N -> minute
+              end) == 30
+    end
+
+    test "S binds second" do
+      point = Tempo.new!(year: 2026, month: 6, day: 15, hour: 14, minute: 30, second: 45)
+
+      assert (case point do
+                ~o[2026Y6M15DT14H30M]S -> second
+              end) == 45
+    end
+
+    test "binding on a time-of-day value does not require date components" do
+      tod = Tempo.new!(hour: 10, minute: 30)
+
+      assert (case tod do
+                ~o[T10H]N -> minute
+              end) == 30
+    end
+  end
+
+  describe "modifier bindings — multiple" do
+    test "DN binds both day and minute" do
+      point = Tempo.new!(year: 2026, month: 6, day: 15, hour: 14, minute: 30)
+
+      assert (case point do
+                ~o[2026Y6M]DN -> {day, minute}
+              end) == {15, 30}
+    end
+
+    test "modifier order within the sigil does not matter" do
+      point = Tempo.new!(year: 2026, month: 6, day: 15, hour: 14, minute: 30)
+
+      assert (case point do
+                ~o[2026Y6M]ND -> {day, minute}
+              end) == {15, 30}
+    end
+
+    test "O and D compose with a fixed year" do
+      today = Tempo.new!(year: 2026, month: 4, day: 24)
+
+      assert (case today do
+                ~o[2026Y]OD -> {month, day}
+              end) == {4, 24}
+    end
+  end
+
+  describe "modifier bindings — match failures" do
+    test "fails when the bound unit is absent from the target" do
+      bare_year = Tempo.new!(year: 2026)
+
+      # Use `case` + fall-through rather than `refute match?/2` so
+      # the unused binding variable doesn't provoke a compile
+      # warning.
+      result =
+        case bare_year do
+          ~o[2026Y]D -> {:matched, day}
+          _ -> :no_match
+        end
+
+      assert result == :no_match
+    end
+
+    test "fails when the sigil's fixed unit disagrees, even with bindings" do
+      today = Tempo.new!(year: 2026, month: 4, day: 24)
+
+      result =
+        case today do
+          ~o[2026Y01M]D -> {:matched, day}
+          _ -> :no_match
+        end
+
+      assert result == :no_match
+    end
+  end
+
+  describe "modifier bindings — expansion-time errors" do
+    test "unknown modifier letter raises ArgumentError" do
+      assert_raise ArgumentError, ~r/does not recognise modifier/, fn ->
+        Code.eval_string(
+          """
+          import Tempo.Sigils
+
+          fn t ->
+            case t do
+              ~o[2026Y]X -> :ok
+            end
+          end
+          """,
+          []
+        )
+      end
+    end
+
+    test "duplicate unit between sigil and modifier raises ArgumentError" do
+      assert_raise ArgumentError, ~r/already present in the sigil/, fn ->
+        Code.eval_string(
+          """
+          import Tempo.Sigils
+
+          fn t ->
+            case t do
+              ~o[2026Y]Y -> :ok
+            end
+          end
+          """,
+          []
+        )
+      end
+    end
+
+    test "mixing Gregorian axis with ISO week axis raises ArgumentError" do
+      assert_raise ArgumentError, ~r/cannot mix calendar axes/, fn ->
+        Code.eval_string(
+          """
+          import Tempo.Sigils
+
+          fn t ->
+            case t do
+              ~o[2026Y4M]W -> :ok
+            end
+          end
+          """,
+          []
+        )
+      end
+    end
+  end
 end

--- a/test/tempo/sigil_test.exs
+++ b/test/tempo/sigil_test.exs
@@ -280,4 +280,152 @@ defmodule Tempo.SigilMatchTest do
       end
     end
   end
+
+  # Phase ③ — matching on the non-`%Tempo{}` structs that the ISO
+  # parser can produce: Duration, Interval, Range (embedded), and
+  # Set.
+
+  describe "matching %Tempo.Duration{}" do
+    test "prefix match on the duration's time list" do
+      duration = Tempo.Duration.new!(year: 1, month: 6)
+      assert match?(~o[P1Y6M], duration)
+    end
+
+    test "prefix allows extra finer components" do
+      duration = Tempo.Duration.new!(year: 1, month: 6, day: 15)
+      assert match?(~o[P1Y6M], duration)
+    end
+
+    test "fails when values disagree" do
+      duration = Tempo.Duration.new!(year: 1, month: 6)
+      refute match?(~o[P2Y6M], duration)
+    end
+
+    test "does not cross-match a Tempo against a Duration sigil" do
+      tempo = Tempo.new!(year: 1, month: 6)
+      refute match?(~o[P1Y6M], tempo)
+    end
+
+    test "does not cross-match a Duration against a Tempo sigil" do
+      duration = Tempo.Duration.new!(year: 1, month: 6)
+      refute match?(~o[1Y6M], duration)
+    end
+
+    test "modifier bindings work on Duration (same `time` shape as Tempo)" do
+      duration = Tempo.Duration.new!(year: 1, month: 6, day: 15)
+
+      assert (case duration do
+                ~o[P1Y]D -> day
+              end) == 15
+    end
+  end
+
+  describe "matching %Tempo.Interval{}" do
+    test "closed interval with two Tempo endpoints" do
+      {:ok, interval} = Tempo.from_iso8601("1984Y/2004Y")
+      assert match?(~o[1984Y/2004Y], interval)
+    end
+
+    test "sigil endpoints are prefix-matched against the interval's endpoints" do
+      {:ok, interval} = Tempo.from_iso8601("1984Y6M/2004Y6M")
+      assert match?(~o[1984Y/2004Y], interval)
+    end
+
+    test "open upper endpoint" do
+      {:ok, interval} = Tempo.from_iso8601("1984/..")
+      assert match?(~o[1984Y/..], interval)
+    end
+
+    test "open lower endpoint" do
+      {:ok, interval} = Tempo.from_iso8601("../2004")
+      assert match?(~o[../2004Y], interval)
+    end
+
+    test "both endpoints open" do
+      {:ok, interval} = Tempo.from_iso8601("../..")
+      assert match?(~o[../..], interval)
+    end
+
+    test "interval with a duration" do
+      {:ok, interval} = Tempo.from_iso8601("P1D/2022-01-01")
+      assert match?(~o[P1D/2022-01-01], interval)
+    end
+
+    test "a closed interval does not match an open-upper sigil" do
+      {:ok, interval} = Tempo.from_iso8601("1984Y/2004Y")
+      refute match?(~o[1984Y/..], interval)
+    end
+
+    test "an open-upper sigil does not match a closed interval" do
+      {:ok, interval} = Tempo.from_iso8601("1984Y/..")
+      refute match?(~o[1984Y/2004Y], interval)
+    end
+  end
+
+  describe "matching %Tempo.Set{}" do
+    # Set sigils whose literal text starts with `[` or `{`
+    # collide with the `~o[…]` and `~o{…}` delimiters, so use
+    # the string-delimiter form `~o"…"` instead.
+
+    test "one-of set" do
+      {:ok, set} = Tempo.from_iso8601("[1984,1986,1988]")
+      assert match?(~o"[1984Y,1986Y,1988Y]", set)
+    end
+
+    test "all-of set" do
+      {:ok, set} = Tempo.from_iso8601("{1960,1961-12}")
+      assert match?(~o"{1960Y,1961Y12M}", set)
+    end
+
+    test "set types do not cross" do
+      {:ok, one_of} = Tempo.from_iso8601("[1984,1986,1988]")
+      refute match?(~o"{1984Y,1986Y,1988Y}", one_of)
+    end
+
+    test "set with an embedded Range member" do
+      {:ok, set} = Tempo.from_iso8601("[1760-01,1760-12..]")
+      assert match?(~o"[1760Y1M,1760Y12M..]", set)
+    end
+
+    test "member count must match" do
+      {:ok, set} = Tempo.from_iso8601("[1984,1986,1988]")
+      refute match?(~o"[1984Y,1986Y]", set)
+    end
+  end
+
+  describe "container expansion-time errors" do
+    test "modifier bindings on an Interval sigil raise" do
+      assert_raise ArgumentError, ~r/only supported on %Tempo\{\}/, fn ->
+        Code.eval_string(
+          """
+          import Tempo.Sigils
+
+          fn t ->
+            case t do
+              ~o[1984Y/2004Y]D -> :ok
+            end
+          end
+          """,
+          []
+        )
+      end
+    end
+
+    test "modifier bindings on a Set sigil raise" do
+      assert_raise ArgumentError, ~r/only supported on %Tempo\{\}/, fn ->
+        Code.eval_string(
+          """
+          import Tempo.Sigils
+
+          fn t ->
+            case t do
+              ~o"[1984Y,1986Y]"Y -> :ok
+            end
+          end
+          """,
+          []
+        )
+      end
+    end
+  end
 end


### PR DESCRIPTION
**NB** On my machine there are 48 failures with formatting, like this:
```
 37) test Tempo.to_string/2 on Tempo.Duration — Localize-backed weeks normalise to days (Tempo.FormatTest)
     test/tempo/format_test.exs:181
     Assertion with == failed
     code:  assert Tempo.to_string(~o"P2W3D") == "17 days"
     left:  "17 d"
     right: "17 days"
     stacktrace:
       test/tempo/format_test.exs:182: (test)
```

I basically left them as is. My tests are all passing.

---

## Match context

When `~o"…"` is used on the left-hand side of a match —
`match?/2`, `case` clauses, `=`, or function-head patterns —
the sigil expands to a **structural pattern** rather than a
literal value. The generated pattern is deliberately permissive:
it constrains only what the sigil string actually names.

### 1. Prefix matching on `%Tempo{}` and `%Tempo.Duration{}`

The sigil string is parsed as usual; the resulting `:time`
keyword list becomes a cons-pattern terminated by a wildcard,
so the sigil matches any value whose `:time` *starts with* the
listed `{unit, value}` pairs. Other struct fields
(`:calendar`, `:shift`, `:extended`, `:qualification`, …) are
left unconstrained — a Gregorian-looking sigil matches a
Hebrew-calendar value just as happily, because the intent of
the sigil is purely temporal.

```elixir
import Tempo.Sigils

today = Tempo.new!(year: 2026, month: 4, day: 24)

match?(~o[2026Y], today)          #=> true  — year prefix
match?(~o[2026Y4M], today)        #=> true  — year+month prefix
match?(~o[2026Y4M24D], today)     #=> true  — full prefix
match?(~o[2026Y1M], today)        #=> false — month disagrees
match?(~o[2025Y], today)          #=> false — year disagrees

hebrew = Tempo.new!(year: 2026, month: 4, day: 24, calendar: Calendrical.Hebrew)
match?(~o[2026Y], hebrew)         #=> true  — :calendar is free

duration = Tempo.Duration.new!(year: 1, month: 6)
match?(~o[P1Y6M], duration)       #=> true
match?(~o[P2Y6M], duration)       #=> false
match?(~o[1Y6M], duration)        #=> false  — %Tempo{} sigil
                                  #            vs %Duration{}
```

### 2. Modifier-driven bindings

Modifier letters after the closing delimiter bind the matched
value's unit to a same-named variable in the caller's scope.
Bindings are only meaningful on `%Tempo{}` and
`%Tempo.Duration{}` values — the only shapes with a
`:time` keyword list to destructure.

Letter → unit mapping (deliberately avoids overloading `M`,
which ISO 8601 uses for both month and minute):

* `Y` — year
* `O` — month (`mOnth`)
* `W` — week
* `D` — day
* `I` — day of year
* `K` — day of week
* `H` — hour
* `N` — minute (`miNute`)
* `S` — second

The pattern builder lays out the canonical calendar-axis slice
between the earliest and latest unit requested (either by the
sigil literal or by a modifier), filling positions not named
with wildcards. Axis choice — Gregorian, ISO week, or ordinal
— is inferred from the union of sigil and modifier units.

```elixir
import Tempo.Sigils

today = Tempo.new!(year: 2026, month: 4, day: 24)

case today do
  ~o[2026Y]D -> day                 #=> 24
end

case today do
  ~o[2026Y]OD -> {month, day}       #=> {4, 24}
end

point = Tempo.new!(year: 2026, month: 6, day: 15,
                   hour: 14, minute: 30, second: 45)

case point do
  ~o[2026Y6M]DN -> {day, minute}    #=> {15, 30}
end

case point do
  ~o[2026Y6M15DT14H30M]S -> second  #=> 45
end

duration = Tempo.Duration.new!(year: 1, month: 6, day: 15)

case duration do
  ~o[P1Y]D -> day                   #=> 15
end
```

A modifier that targets a unit the matched value doesn't carry
simply fails to match; the `case` falls through to the next
clause. Modifier order inside the sigil is irrelevant —
`~o[2026Y]DN` and `~o[2026Y]ND` expand to the same pattern.

#### Expansion-time errors

* Unknown modifier letter → `ArgumentError`.
* Modifier targets a unit already fixed by the sigil (e.g.
  `~o[2026Y]Y`) → `ArgumentError`.
* Mixing calendar axes (e.g. `~o[2026Y4M]W` — Gregorian
  month plus ISO week) → `ArgumentError`.

### 3. Matching containers

The sigil also expands to a structural pattern when the parsed
value is a container: `%Tempo.Interval{}`, `%Tempo.Range{}`,
or `%Tempo.Set{}`. Each endpoint is itself prefix-matched
using the phase-1 rules, so an endpoint sigil like `~o"2022Y"`
inside an interval matches any Tempo whose `:time` starts with
year 2022.

Container patterns only constrain fields the sigil string
actually names. For intervals, that means `from` and `to` are
always constrained, while `duration`, `recurrence`,
`direction`, and `repeat_rule` are only constrained when they
differ from their struct defaults — so
`~o[1984Y/2004Y]` doesn't accidentally require
`metadata: %{}`.

```elixir
import Tempo.Sigils

{:ok, closed}   = Tempo.from_iso8601("1984Y/2004Y")
{:ok, open_up}  = Tempo.from_iso8601("1984/..")
{:ok, dur_iv}   = Tempo.from_iso8601("P1D/2022-01-01")

match?(~o[1984Y/2004Y], closed)    #=> true
match?(~o[1984Y/..], closed)       #=> false — closed vs open
match?(~o[1984Y/..], open_up)      #=> true
match?(~o[../..], open_up)         #=> false
match?(~o[P1D/2022-01-01], dur_iv) #=> true

{:ok, one_of}   = Tempo.from_iso8601("[1984,1986,1988]")
{:ok, all_of}   = Tempo.from_iso8601("{1960,1961-12}")

match?(~o"[1984Y,1986Y,1988Y]", one_of)  #=> true
match?(~o"{1960Y,1961Y12M}", all_of)     #=> true
match?(~o"{1984Y,1986Y,1988Y}", one_of)  #=> false — :one ≠ :all
```

Sets whose literal text begins with `[` or `{` collide with
the `~o[…]` and `~o{…}` delimiters, so use the string-delim
form `~o"…"` for them.

Set members are matched in order and by count — a sigil set
with three members never matches a value with two or four.
Ranges (`%Tempo.Range{first: …, last: …}`) are matched
structurally whether they appear at the top level or nested
inside a `%Tempo.Set{}`.

#### Modifiers on containers

Modifier bindings are **not** accepted on `%Tempo.Interval{}`,
`%Tempo.Range{}`, `%Tempo.Set{}`, or `%Tempo.IntervalSet{}`
sigils — there is no single keyword-list `:time` to
destructure. Using one raises `ArgumentError` at expansion
time. Reach into an interval's endpoint manually:

```elixir
case interval do
  ~o[1984Y/..] ->
    %Tempo.Interval{from: ~o[1984Y]D = from} = interval
    from.time[:day]
end
```

### 4. Guards

Patterns from `~o"…"` cannot appear in a `when` clause. The
sigil detects the `:guard` context and raises
`ArgumentError` with a clear message — use a preceding match
+ `==` comparison instead.

### 5. What match context does **not** do

* **No calendar modifier.** `W` in value context selects the
  ISO Week calendar; in match context it always means "bind
  `:week`". Sigils in match context always parse their
  string as Gregorian and leave the matched value's
  `:calendar` field unconstrained.

* **No stdlib types.** `~o"…"` produces a `%Tempo{}`-family
  pattern, so it cannot match `%Date{}`, `%Time{}`,
  `%NaiveDateTime{}`, or `%DateTime{}`. For those, use
  `~D`/`~T`/`~N`/`~U` directly, or convert the value with
  `Tempo.from_elixir/1` before matching.

* **No complex time elements.** Groups, selections, ranges,
  margin-of-error tuples, and continuations aren't expressible
  as static Elixir patterns — attempting to use a sigil that
  contains them in match context raises `ArgumentError`.